### PR TITLE
Added support to Windows Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The documentation is on the project wiki [click here](https://github.com/lskbr/c
 
 Installation package:
 ---------------------
-Version 0.7.2
+Version 0.8.0
 
 PIP:
 

--- a/colorconsole/ansi_codes.py
+++ b/colorconsole/ansi_codes.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+#    colorconsole
+#    Copyright © 2010-2022 Nilo Menezes
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# Inspired/copied/adapted from:
+#
+# output.py from Gentoo and
+# http://code.activestate.com/recipes/572182-how-to-implement-kbhit-on-linux/ and
+# http://www.burgaud.com/bring-colors-to-the-windows-console-with-python/
+# https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+# https://devblogs.microsoft.com/commandline/author/richturnmicrosoft-com/
+# https://docs.microsoft.com/en-us/windows/console/setconsolemode
+
+
+ESCAPE = "\x1b["
+CODES = {
+    "reset": ESCAPE + "0m",
+    "bold": ESCAPE + "1m",
+    "clear": ESCAPE + "2J",
+    "clear_eol": ESCAPE + "K",
+    "gotoxy": ESCAPE + "%d;%dH",
+    "move_up": ESCAPE + "%dA",
+    "move_down": ESCAPE + "%dB",
+    "move_right": ESCAPE + "%dC",
+    "move_left": ESCAPE + "%dD",
+    "save": ESCAPE + "s",
+    "restore": ESCAPE + "u",
+    "dim": ESCAPE + "2m",
+    "underline": ESCAPE + "4m",
+    "underline_off": ESCAPE + "24m",
+    "blink": ESCAPE + "5m",
+    "blink_off": ESCAPE + "25m",
+    "reverse": ESCAPE + "7m",
+    "reverse_off": ESCAPE + "27m",
+    "invisible": ESCAPE + "8m",
+    "italic": ESCAPE + "3m",
+    "italic_off": ESCAPE + "23m",
+    "crossed": ESCAPE + "9m",
+    "crossed_off": ESCAPE + "29m",
+}
+
+COLORS_FG = {
+    0: "0;30m",  # black
+    4: "0;31m",  # red
+    2: "0;32m",  # green
+    6: "0;33m",  # yellow
+    1: "0;34m",  # blue
+    5: "0;35m",  # magenta
+    3: "0;36m",  # cyan
+    7: "0;37m",  # white
+    8: "1;30m",  # grey
+    12: "1;31m",  # bright blue
+    10: "1;32m",  # bright green
+    14: "1;33m",  # bright cyan
+    9: "1;34m",
+    13: "1;35m",
+    11: "1;36m",
+    15: "1;37m",  # white
+}
+
+COLORS_BK = {
+    0: "40m",  # black
+    4: "41m",  # red
+    2: "42m",  # green
+    6: "43m",  # yellow
+    1: "44m",  # blue
+    5: "45m",  # magenta
+    3: "46m",  # cyan
+    7: "47m",  # white
+    8: "100m",
+    12: "101m",
+    10: "102m",
+    14: "103m",
+    9: "104m",
+    13: "105m",
+    11: "106m",
+    15: "107m",
+}

--- a/colorconsole/terminal.py
+++ b/colorconsole/terminal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #    colorconsole
-#    Copyright (C) 2010-2015 Nilo Menezes
+#    Copyright © 2010-2022 Nilo Menezes
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -24,79 +24,56 @@
 # http://www.burgaud.com/bring-colors-to-the-windows-console-with-python/
 #
 
-# Added for Python 2.6 compatibility
-from __future__ import print_function
 import os
 import sys
 
 colors = {
-          "BLACK": 0,
-          "BLUE": 1,
-          "GREEN": 2,
-          "CYAN": 3,
-          "RED": 4,
-          "PURPLE": 5,
-          "BROWN": 6,
-          "LGREY": 7,
-          "DGRAY": 8,
-          "LBLUE": 9,
-          "LGREEN": 10,
-          "LCYAN": 11,
-          "LRED": 12,
-          "LPURPLE": 13,
-          "YELLOW": 14,
-          "WHITE": 15
-         }
+    "BLACK": 0,
+    "BLUE": 1,
+    "GREEN": 2,
+    "CYAN": 3,
+    "RED": 4,
+    "PURPLE": 5,
+    "BROWN": 6,
+    "LGREY": 7,
+    "DGRAY": 8,
+    "LBLUE": 9,
+    "LGREEN": 10,
+    "LCYAN": 11,
+    "LRED": 12,
+    "LPURPLE": 13,
+    "YELLOW": 14,
+    "WHITE": 15,
+}
+
+color_numbers_to_names = {v: k for k, v in colors.items()}
+
+
+def make_ansi():
+    import colorconsole.ansi
+
+    return colorconsole.ansi.Terminal()
+
+
+def make_conemu():
+    import colorconsole.conemu
+
+    return colorconsole.conemu.Terminal()
+
+
+def make_winconsole():
+    import colorconsole.win
+
+    return colorconsole.win.Terminal()
+
 
 def get_terminal(conEmu=False):
     if os.name == "posix":
-        import colorconsole.ansi
-        return colorconsole.ansi.Terminal()
+        return make_ansi()
     elif os.name == "nt":
         if conEmu:
-            import colorconsole.conemu
-            return colorconsole.conemu.Terminal()
+            return make_conemu()
         else:
-            import colorconsole.win
-            return colorconsole.win.Terminal()
+            return make_winconsole()
     else:
         raise RuntimeError("Unknown or unsupported terminal")
-
-
-def test():
-    t = get_terminal()
-    t.enable_unbuffered_input_mode()
-    t.clear()
-    t.gotoXY(0, 0)
-    t.set_title("Testing output")
-    print("            Foreground 111111")
-    print("Background   0123456789012345")
-    for b in range(8):
-        t.reset()
-        print("            ", end="")
-        print(b, end="")
-        for f in range(16):
-            t.cprint(f, b, f % 10)
-        print()
-    a = 0
-    b = 0
-    t.reset()
-    try:
-        while(True):
-            t.print_at(a, 20 + b % 20, ".")
-            if t.kbhit(0.01):
-                t.print_at(50, 6, ord(t.getch()))
-            t.print_at(40, 5, "%d %d" % (a, b))
-            b += 1
-            a = b / 20.0 % 20
-            t.print_at(40, 6, b)
-            t.print_at(a, 20 + b % 20, "*")
-            sys.stdout.flush()
-    except KeyboardInterrupt:
-        pass
-    t.clear()
-    t.reset()
-    t.restore_buffered_mode()
-
-if __name__ == "__main__":
-    test()

--- a/colorconsole/win.py
+++ b/colorconsole/win.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #    colorconsole
-#    Copyright (C) 2010-2015 Nilo Menezes
+#    Copyright © 2010-2022 Nilo Menezes
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -28,59 +28,31 @@
 #            for set_title bug fixing and enhancements
 #
 #
-# Added for Python 2.6 compatibility
-from __future__ import print_function
+
 import sys
+import os
 import msvcrt
-from ctypes import windll, Structure, c_short, c_ushort, byref, c_uint, c_wchar_p
+from ctypes import byref
 
-SHORT = c_short
-WORD = c_ushort
-DWORD = c_uint
-
-
-class COORD(Structure):
-    """struct in wincon.h."""
-
-    _fields_ = [
-                 ("X", SHORT),
-                 ("Y", SHORT)
-                ]
-
-
-class SMALL_RECT(Structure):
-    """struct in wincon.h."""
-
-    _fields_ = [
-                ("Left", SHORT),
-                ("Top", SHORT),
-                ("Right", SHORT),
-                ("Bottom", SHORT)
-                ]
-
-
-class CONSOLE_SCREEN_BUFFER_INFO(Structure):
-    """struct in wincon.h."""
-
-    _fields_ = [
-                ("dwSize", COORD),
-                ("dwCursorPosition", COORD),
-                ("wAttributes", WORD),
-                ("srWindow", SMALL_RECT),
-                ("dwMaximumWindowSize", COORD)
-                ]
-
-
-SetConsoleTextAttribute = windll.kernel32.SetConsoleTextAttribute
-GetConsoleScreenBufferInfo = windll.kernel32.GetConsoleScreenBufferInfo
-# Added for compatibility between python 2 and 3
-SetConsoleTitle = windll.kernel32.SetConsoleTitleW
-cstring_p = c_wchar_p
-GetConsoleTitle = windll.kernel32.GetConsoleTitleW
-SetConsoleCursorPosition = windll.kernel32.SetConsoleCursorPosition
-FillConsoleOutputCharacter = windll.kernel32.FillConsoleOutputCharacterA
-FillConsoleOutputAttribute = windll.kernel32.FillConsoleOutputAttribute
-WriteConsoleW = windll.kernel32.WriteConsoleW
+from .ansi_codes import ESCAPE, CODES
+from .win_common import (
+    SetConsoleTextAttribute,
+    GetConsoleScreenBufferInfo,
+    SetConsoleTitle,
+    SetConsoleCursorPosition,
+    FillConsoleOutputCharacter,
+    FillConsoleOutputAttribute,
+    WriteConsoleW,
+    GetStdHandle,
+    CONSOLE_SCREEN_BUFFER_INFO,
+    DWORD,
+    COORD,
+    cstring_p,
+    GetConsoleMode,
+    SetConsoleMode,
+    ENABLE_VIRTUAL_TERMINAL_INPUT,
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+)
 
 
 class Terminal:
@@ -88,18 +60,286 @@ class Terminal:
     STD_OUTPUT_HANDLE = -11
     WAIT_TIMEOUT = 0x00000102
     WAIT_OBJECT_0 = 0
+    # Color pallete for Windows terminal xterm-256 colors mode
+    WT_COLORS_256 = [
+        "0;0;0",  # 0
+        "128;0;0",  # 1
+        "0;128;0",  # 2
+        "128;128;0",  # 3
+        "0;0;128",  # 4
+        "128;0;128",  # 5
+        "0;128;128",  # 6
+        "192;192;192",  # 7
+        "128;128;128",  # 8
+        "255;0;0",  # 9
+        "0;255;0",  # 10
+        "255;255;0",  # 11
+        "0;0;255",  # 12
+        "255;0;255",  # 13
+        "0;255;255",  # 14
+        "255;255;255",  # 15
+        "0;0;0",  # 16
+        "0;0;95",  # 17
+        "0;0;135",  # 18
+        "0;0;175",  # 19
+        "0;0;215",  # 20
+        "0;0;255",  # 21
+        "0;95;0",  # 22
+        "0;95;95",  # 23
+        "0;95;135",  # 24
+        "0;95;175",  # 25
+        "0;95;215",  # 26
+        "0;95;255",  # 27
+        "0;135;0",  # 28
+        "0;135;95",  # 29
+        "0;135;135",  # 30
+        "0;135;175",  # 31
+        "0;135;215",  # 32
+        "0;135;255",  # 33
+        "0;175;0",  # 34
+        "0;175;95",  # 35
+        "0;175;135",  # 36
+        "0;175;175",  # 37
+        "0;175;215",  # 38
+        "0;175;255",  # 39
+        "0;215;0",  # 40
+        "0;215;95",  # 41
+        "0;215;135",  # 42
+        "0;215;175",  # 43
+        "0;215;215",  # 44
+        "0;215;255",  # 45
+        "0;255;0",  # 46
+        "0;255;95",  # 47
+        "0;255;135",  # 48
+        "0;255;175",  # 49
+        "0;255;215",  # 50
+        "0;255;255",  # 51
+        "95;0;0",  # 52
+        "95;0;95",  # 53
+        "95;0;135",  # 54
+        "95;0;175",  # 55
+        "95;0;215",  # 56
+        "95;0;255",  # 57
+        "95;95;0",  # 58
+        "95;95;95",  # 59
+        "95;95;135",  # 60
+        "95;95;175",  # 61
+        "95;95;215",  # 62
+        "95;95;255",  # 63
+        "95;135;0",  # 64
+        "95;135;95",  # 65
+        "95;135;135",  # 66
+        "95;135;175",  # 67
+        "95;135;215",  # 68
+        "95;135;255",  # 69
+        "95;175;0",  # 70
+        "95;175;95",  # 71
+        "95;175;135",  # 72
+        "95;175;175",  # 73
+        "95;175;215",  # 74
+        "95;175;255",  # 75
+        "95;215;0",  # 76
+        "95;215;95",  # 77
+        "95;215;135",  # 78
+        "95;215;175",  # 79
+        "95;215;215",  # 80
+        "95;215;255",  # 81
+        "95;255;0",  # 82
+        "95;255;95",  # 83
+        "95;255;135",  # 84
+        "95;255;175",  # 85
+        "95;255;215",  # 86
+        "95;255;255",  # 87
+        "135;0;0",  # 88
+        "135;0;95",  # 89
+        "135;0;135",  # 90
+        "135;0;175",  # 91
+        "135;0;215",  # 92
+        "135;0;255",  # 93
+        "135;95;0",  # 94
+        "135;95;95",  # 95
+        "135;95;135",  # 96
+        "135;95;175",  # 97
+        "135;95;215",  # 98
+        "135;95;255",  # 99
+        "135;135;0",  # 100
+        "135;135;95",  # 101
+        "135;135;135",  # 102
+        "135;135;175",  # 103
+        "135;135;215",  # 104
+        "135;135;255",  # 105
+        "135;175;0",  # 106
+        "135;175;95",  # 107
+        "135;175;135",  # 108
+        "135;175;175",  # 109
+        "135;175;215",  # 110
+        "135;175;255",  # 111
+        "135;215;0",  # 112
+        "135;215;95",  # 113
+        "135;215;135",  # 114
+        "135;215;175",  # 115
+        "135;215;215",  # 116
+        "135;215;255",  # 117
+        "135;255;0",  # 118
+        "135;255;95",  # 119
+        "135;255;135",  # 120
+        "135;255;175",  # 121
+        "135;255;215",  # 122
+        "135;255;255",  # 123
+        "175;0;0",  # 124
+        "175;0;95",  # 125
+        "175;0;135",  # 126
+        "175;0;175",  # 127
+        "175;0;215",  # 128
+        "175;0;255",  # 129
+        "175;95;0",  # 130
+        "175;95;95",  # 131
+        "175;95;135",  # 132
+        "175;95;175",  # 133
+        "175;95;215",  # 134
+        "175;95;255",  # 135
+        "175;135;0",  # 136
+        "175;135;95",  # 137
+        "175;135;135",  # 138
+        "175;135;175",  # 139
+        "175;135;215",  # 140
+        "175;135;255",  # 141
+        "175;175;0",  # 142
+        "175;175;95",  # 143
+        "175;175;135",  # 144
+        "175;175;175",  # 145
+        "175;175;215",  # 146
+        "175;175;255",  # 147
+        "175;215;0",  # 148
+        "175;215;95",  # 149
+        "175;215;135",  # 150
+        "175;215;175",  # 151
+        "175;215;215",  # 152
+        "175;215;255",  # 153
+        "175;255;0",  # 154
+        "175;255;95",  # 155
+        "175;255;135",  # 156
+        "175;255;175",  # 157
+        "175;255;215",  # 158
+        "175;255;255",  # 159
+        "215;0;0",  # 160
+        "215;0;95",  # 161
+        "215;0;135",  # 162
+        "215;0;175",  # 163
+        "215;0;215",  # 164
+        "215;0;255",  # 165
+        "215;95;0",  # 166
+        "215;95;95",  # 167
+        "215;95;135",  # 168
+        "215;95;175",  # 169
+        "215;95;215",  # 170
+        "215;95;255",  # 171
+        "215;135;0",  # 172
+        "215;135;95",  # 173
+        "215;135;135",  # 174
+        "215;135;175",  # 175
+        "215;135;215",  # 176
+        "215;135;255",  # 177
+        "215;175;0",  # 178
+        "215;175;95",  # 179
+        "215;175;135",  # 180
+        "215;175;175",  # 181
+        "215;175;215",  # 182
+        "215;175;255",  # 183
+        "215;215;0",  # 184
+        "215;215;95",  # 185
+        "215;215;135",  # 186
+        "215;215;175",  # 187
+        "215;215;215",  # 188
+        "215;215;255",  # 189
+        "215;255;0",  # 190
+        "215;255;95",  # 191
+        "215;255;135",  # 192
+        "215;255;175",  # 193
+        "215;255;215",  # 194
+        "215;255;255",  # 195
+        "255;0;0",  # 196
+        "255;0;95",  # 197
+        "255;0;135",  # 198
+        "255;0;175",  # 199
+        "255;0;215",  # 200
+        "255;0;255",  # 201
+        "255;95;0",  # 202
+        "255;95;95",  # 203
+        "255;95;135",  # 204
+        "255;95;175",  # 205
+        "255;95;215",  # 206
+        "255;95;255",  # 207
+        "255;135;0",  # 208
+        "255;135;95",  # 209
+        "255;135;135",  # 210
+        "255;135;175",  # 211
+        "255;135;215",  # 212
+        "255;135;255",  # 213
+        "255;175;0",  # 214
+        "255;175;95",  # 215
+        "255;175;135",  # 216
+        "255;175;175",  # 217
+        "255;175;215",  # 218
+        "255;175;255",  # 219
+        "255;215;0",  # 220
+        "255;215;95",  # 221
+        "255;215;135",  # 222
+        "255;215;175",  # 223
+        "255;215;215",  # 224
+        "255;215;255",  # 225
+        "255;255;0",  # 226
+        "255;255;95",  # 227
+        "255;255;135",  # 228
+        "255;255;175",  # 229
+        "255;255;215",  # 230
+        "255;255;255",  # 231
+        "8;8;8",  # 232
+        "18;18;18",  # 233
+        "28;28;28",  # 234
+        "38;38;38",  # 235
+        "48;48;48",  # 236
+        "58;58;58",  # 237
+        "68;68;68",  # 238
+        "78;78;78",  # 239
+        "88;88;88",  # 240
+        "98;98;98",  # 241
+        "108;108;108",  # 242
+        "118;118;118",  # 243
+        "128;128;128",  # 244
+        "138;138;138",  # 245
+        "148;148;148",  # 246
+        "158;158;158",  # 247
+        "168;168;168",  # 248
+        "178;178;178",  # 249
+        "188;188;188",  # 250
+        "198;198;198",  # 251
+        "208;208;208",  # 252
+        "218;218;218",  # 253
+        "228;228;228",  # 254
+        "238;238;238",  # 255
+    ]
 
     def __init__(self):
         self.fg = None
         self.bk = None
         self.havecolor = 1
         self.dotitles = 1
-        self.stdout_handle = windll.kernel32.GetStdHandle(Terminal.STD_OUTPUT_HANDLE)
-        self.stdin_handle = windll.kernel32.GetStdHandle(Terminal.STD_INPUT_HANDLE)
+        self.stdout_handle = GetStdHandle(Terminal.STD_OUTPUT_HANDLE)
+        self.stdin_handle = GetStdHandle(Terminal.STD_INPUT_HANDLE)
         self.reset_attrib = self.__get_text_attr()
         self.savedX = 0
         self.savedY = 0
         self.type = "WIN"
+        self.new_windows_terminal = os.getenv("WT_SESSION") is not None or False
+        if self.new_windows_terminal:
+            self.enable_virtual_terminal_processing()
+
+    def enable_virtual_terminal_processing(self):
+        z = DWORD()
+        GetConsoleMode(self.stdout_handle, byref(z))
+        z = DWORD(z.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+        SetConsoleMode(self.stdout_handle, z)
 
     def restore_buffered_mode(self):
         pass
@@ -154,8 +394,11 @@ class Terminal:
         self.win_print(text)
 
     def print_at(self, x, y, text):
-            self.gotoXY(x, y)
-            self.win_print(text)
+        self.gotoXY(x, y)
+        self.win_print(text)
+
+    def print(self, text):
+        self.win_print(text)
 
     def clear(self):  # From kb q99261
         rp = COORD()
@@ -164,10 +407,10 @@ class Terminal:
         GetConsoleScreenBufferInfo(self.stdout_handle, byref(csbi))
         sx = csbi.dwSize.X * csbi.dwSize.Y
 
-        FillConsoleOutputCharacter(self.stdout_handle, 32,
-                                   sx, rp, byref(wr))
-        FillConsoleOutputAttribute(self.stdout_handle, csbi.wAttributes,
-                                   sx, rp, byref(wr))
+        FillConsoleOutputCharacter(self.stdout_handle, 32, sx, rp, byref(wr))
+        FillConsoleOutputAttribute(
+            self.stdout_handle, csbi.wAttributes, sx, rp, byref(wr)
+        )
 
     def gotoXY(self, x, y):
         p = COORD()
@@ -192,7 +435,7 @@ class Terminal:
         csbi = self.__get_console_info()
         ax = csbi.dwCursorPosition.X
         ay = csbi.dwCursorPosition.Y
-        self.gotoXY(ax+dx, ay+dy)
+        self.gotoXY(ax + dx, ay + dy)
 
     def move_left(self, c=1):
         self.__move_from(-c, 0)
@@ -214,21 +457,96 @@ class Terminal:
         csbi = self.__get_console_info()
         return csbi.dwSize.Y
 
+    def underline(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["underline"])
+            sys.stdout.flush()
+
+    def underline_off(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["underline_off"])
+            sys.stdout.flush()
+
     def blink(self):
-        pass
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["blink"])
+            sys.stdout.flush()
+
+    def blink_off(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["blink_off"])
+            sys.stdout.flush()
 
     def reverse(self):
-        pass
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["reverse"])
+            sys.stdout.flush()
+
+    def reverse_off(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["reverse_off"])
+            sys.stdout.flush()
+
+    def italic(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["italic"])
+            sys.stdout.flush()
+
+    def italic_off(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["italic_off"])
+            sys.stdout.flush()
+
+    def crossed(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["crossed"])
+            sys.stdout.flush()
+
+    def crossed_off(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["crossed_off"])
+            sys.stdout.flush()
 
     def invisible(self):
-        pass
+        if self.new_windows_terminal:
+            sys.stdout.write(CODES["invisible"])
+            sys.stdout.flush()
 
     def reset_colors(self):
         self.reset()
 
     def win_print(self, x):
-        if(type(x) != str and type(x) != unicode):
+        if type(x) != str:
             x = str(x)
-        l = len(x)
+        length = len(x)
         w = DWORD(0)
-        WriteConsoleW(self.stdout_handle, cstring_p(x), l, byref(w), None)
+        WriteConsoleW(self.stdout_handle, cstring_p(x), length, byref(w), None)
+
+    def xterm256_set_fg_color(self, color):
+        if self.new_windows_terminal:
+            rgb = self.WT_COLORS_256[color]
+            sys.stdout.write(ESCAPE + f"38;2;{rgb}m")
+            sys.stdout.flush()
+
+    def xterm256_set_bk_color(self, color):
+        if self.new_windows_terminal:
+            rgb = self.WT_COLORS_256[color]
+            sys.stdout.write(ESCAPE + f"48;2;{rgb}m")
+            sys.stdout.flush()
+
+    def xterm24bit_set_fg_color(self, r, g, b):
+        if self.new_windows_terminal:
+            sys.stdout.write(ESCAPE + "38;2;%d;%d;%dm" % (r, g, b))
+            sys.stdout.flush()
+
+    def xterm24bit_set_bk_color(self, r, g, b):
+        if self.new_windows_terminal:
+            sys.stdout.write(ESCAPE + "48;2;%d;%d;%dm" % (r, g, b))
+            sys.stdout.flush()
+
+    def default_foreground(self):
+        if self.new_windows_terminal:
+            sys.stdout.write(ESCAPE + "39m")
+
+    def default_background(self):
+        sys.stdout.write(ESCAPE + "49m")

--- a/colorconsole/win_common.py
+++ b/colorconsole/win_common.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+#
+#    colorconsole
+#    Copyright © 2010-2022 Nilo Menezes
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+from ctypes import windll, Structure, c_short, c_ushort, c_uint, c_wchar_p
+
+SHORT = c_short
+WORD = c_ushort
+DWORD = c_uint
+
+
+class COORD(Structure):
+    """struct in wincon.h."""
+
+    _fields_ = [("X", SHORT), ("Y", SHORT)]
+
+
+class SMALL_RECT(Structure):
+    """struct in wincon.h."""
+
+    _fields_ = [("Left", SHORT), ("Top", SHORT), ("Right", SHORT), ("Bottom", SHORT)]
+
+
+class CONSOLE_SCREEN_BUFFER_INFO(Structure):
+    """struct in wincon.h."""
+
+    _fields_ = [
+        ("dwSize", COORD),
+        ("dwCursorPosition", COORD),
+        ("wAttributes", WORD),
+        ("srWindow", SMALL_RECT),
+        ("dwMaximumWindowSize", COORD),
+    ]
+
+
+cstring_p = c_wchar_p
+
+SetConsoleTextAttribute = windll.kernel32.SetConsoleTextAttribute
+GetConsoleScreenBufferInfo = windll.kernel32.GetConsoleScreenBufferInfo
+SetConsoleTitle = windll.kernel32.SetConsoleTitleW
+GetConsoleTitle = windll.kernel32.GetConsoleTitleW
+SetConsoleCursorPosition = windll.kernel32.SetConsoleCursorPosition
+FillConsoleOutputCharacter = windll.kernel32.FillConsoleOutputCharacterA
+FillConsoleOutputAttribute = windll.kernel32.FillConsoleOutputAttribute
+WaitForSingleObject = windll.kernel32.WaitForSingleObject
+ReadConsoleA = windll.kernel32.ReadConsoleA
+WriteConsoleW = windll.kernel32.WriteConsoleW
+GetConsoleMode = windll.kernel32.GetConsoleMode
+SetConsoleMode = windll.kernel32.SetConsoleMode
+GetStdHandle = windll.kernel32.GetStdHandle
+
+ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
+ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004

--- a/samples/example3.py
+++ b/samples/example3.py
@@ -5,27 +5,31 @@ screen = terminal.get_terminal()
 screen.clear()
 screen.set_title("Example 3")
 
-if screen.type == "WIN":
+if screen.type == "WIN" and not screen.new_windows_terminal:
     raise RuntimeError("24 bit mode not supported on Windows.")
 
-screen.underline()
 screen.blink()
+screen.underline()
 screen.print_at(0, 0, "Color table 24 bits")
 screen.reset()
 
 c = 0
 screen.gotoXY(0, 3)
-for r in range(256):
-    for g in range(256):
-        for b in range(256):
-            screen.xterm24bit_set_bk_color(r, g, b)
-            print(" ", end="")
-            c += 1
-            if (c+1) % 64 == 0:
-                print()
-            if (c+1) % 1024 == 0:
-                screen.gotoXY(0, 3)
-print()
-screen.reset_colors()
-# Waits for a single key touch before ending.
-screen.getch()
+try:
+    for r in range(256):
+        for g in range(256):
+            for b in range(256):
+                screen.xterm24bit_set_bk_color(r, g, b)
+                screen.print(" ")
+                c += 1
+                if (c + 1) % 64 == 0:
+                    print()
+                if (c + 1) % 1024 == 0:
+                    screen.gotoXY(0, 3)
+    print()
+    # Waits for a single key touch before ending.
+    screen.getch()
+except KeyboardInterrupt:
+    pass
+finally:
+    screen.reset_colors()

--- a/samples/simple_test.py
+++ b/samples/simple_test.py
@@ -1,0 +1,82 @@
+import sys
+from colorconsole import terminal
+
+from colorconsole.terminal import color_numbers_to_names, colors, get_terminal
+
+
+def test():
+    t = get_terminal()
+    t.enable_unbuffered_input_mode()
+    t.set_color(fg=2, bk=0)
+    t.clear()
+    t.gotoXY(0, 0)
+    t.set_title("Testing output")
+    # Terminal Type
+    t.set_color(fg=2, bk=0)
+    print(f"Terminal Type: {t.type}")
+    print(f"Windows terminal: {t.new_windows_terminal}")
+    print("\n            Foreground 111111")
+    print("Background   0123456789012345")
+    for b in range(8):
+        t.reset()
+        print("            ", end="")
+        print(b, end="")
+        for f in range(16):
+            t.cprint(f, b, f % 10)
+        print()
+    # Color name mapping
+    for b in range(16):
+        t.gotoXY(50, b + 2)
+        t.cprint(0, b, "       ")
+        t.gotoXY(60, b + 2)
+        t.cprint(colors["WHITE"], colors["BLACK"], color_numbers_to_names[b])
+    # 256-colors
+    t.print_at(70, 1, "0123456789ABCDEF")
+    for line, x in enumerate("0123456789ABCDEF"):
+        t.print_at(69, 2 + line, x)
+    for color in range(256):
+        t.xterm256_set_bk_color(color)
+        t.xterm256_set_fg_color(~color)
+        t.gotoXY(70 + color % 16, color // 16 + 2)
+        t.print("X")
+    # Special attributes
+    t.set_color(fg=2, bk=0)
+    print()
+    t.blink()
+    print("BLINK")
+    t.blink_off()
+    t.reverse()
+    print("REVERSE")
+    t.reverse_off()
+    t.underline()
+    print("underline")
+    t.underline_off()
+    t.italic()
+    print("Italic")
+    t.italic_off()
+    t.crossed()
+    print("Crossed")
+    t.crossed_off()
+    # Keyboard read (input)
+    t.set_color(fg=2, bk=0)
+    a = 0
+    b = 0
+    try:
+        t.print_at(0, 15, "Keyboard input")
+        while True:
+            t.print_at(a % 30, 17, ".")
+            if t.kbhit(0.1):
+                ch = t.getch()
+                t.print_at(0, 18, f"Last pressed: {str(ch):8s} - {ord(ch):5d}")
+            a += 1
+            sys.stdout.flush()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        t.restore_buffered_mode()
+        t.reset()
+    t.clear()
+
+
+if __name__ == "__main__":
+    test()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #    colorconsole
-#    Copyright (C) 2010-2015 Nilo Menezes
+#    Copyright (C) 2010-2022 Nilo Menezes
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -19,30 +19,36 @@
 
 from distutils.core import setup
 
-setup(name='colorconsole',
-      version='0.7.2',
-      description="Simple console routines to enable colors and cursor positioning.",
-      author='Nilo Menezes',
-      author_email='nilo@nilo.pro.br',
-      url='https://github.com/lskbr/colorconsole',
-      packages=['colorconsole'],
-      license="LGPL",
-      scripts=[],
-      long_description="""colorconsole uses a common set of console (text mode) primitives, \
+setup(
+    name="colorconsole",
+    version="0.8.0",
+    description="Simple console routines to enable colors and cursor positioning.",
+    author="Nilo Menezes",
+    author_email="nilo@nilo.pro.br",
+    url="https://github.com/lskbr/colorconsole",
+    packages=["colorconsole"],
+    license="LGPL",
+    scripts=[],
+    long_description="""colorconsole uses a common set of console (text mode) primitives, \
 available on Windows, Linux and Mac OS X. The API is the same on all operating systems and \
 applications should run without modifications on any of them. The Windows API or ANSI scape \
 codes are used depending on the platform. This library is licensed under the terms of \
 the GNU LGPL.""",
-      classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-          'Intended Audience :: End Users/Desktop',
-          'Intended Audience :: Developers',
-          'Intended Audience :: System Administrators',
-          'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-          'Operating System :: MacOS :: MacOS X',
-          'Operating System :: Microsoft :: Windows',
-          'Operating System :: POSIX',
-          'Programming Language :: Python',
-      ],
-      )
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+    ],
+)


### PR DESCRIPTION
Fixed color table (Windows -> Linux color numbers)
Added 256 color pallet on Windows Terminal to enhance compatibility
Added shortcut methods to support italics, underline, crossed, blink and reverse